### PR TITLE
Proxy node behavior

### DIFF
--- a/packages/examples/hello_world/src/main.rs
+++ b/packages/examples/hello_world/src/main.rs
@@ -1,6 +1,5 @@
 use rdom::config::ScreenMetrics;
 use rdom::node::concrete::*;
-use rdom::node::NodeBehavior;
 use rdom::sandbox::Sandbox;
 
 fn main() {

--- a/packages/rdom/src/behavior/element.rs
+++ b/packages/rdom/src/behavior/element.rs
@@ -1,6 +1,6 @@
 #![macro_use]
 
-pub trait ElementBehavior {}
+pub(crate) trait ElementBehavior {}
 pub struct ElementBehaviorStorage;
 
 /// Implements ElementBehavior

--- a/packages/rdom/src/behavior/mod.rs
+++ b/packages/rdom/src/behavior/mod.rs
@@ -1,5 +1,5 @@
-pub(crate) use super::node::NodeBehavior;
 pub(crate) use self::parent_node::ParentNodeBehavior;
+pub(crate) use super::node::NodeBehavior;
 
 /// Macro for generating preludes and enforcing mod names
 macro_rules! generate_preludes {

--- a/packages/rdom/src/behavior/mod.rs
+++ b/packages/rdom/src/behavior/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) use super::node::NodeBehavior;
+pub(crate) use self::parent_node::ParentNodeBehavior;
 
 /// Macro for generating preludes and enforcing mod names
 macro_rules! generate_preludes {

--- a/packages/rdom/src/behavior/mod.rs
+++ b/packages/rdom/src/behavior/mod.rs
@@ -1,4 +1,4 @@
-pub use super::node::NodeBehavior;
+pub(crate) use super::node::NodeBehavior;
 
 /// Macro for generating preludes and enforcing mod names
 macro_rules! generate_preludes {
@@ -6,12 +6,12 @@ macro_rules! generate_preludes {
         paste::paste! {
             $(
                 pub mod [<$modname _prelude>] {
-                    pub use super::$modname::{
+                    pub(crate) use super::$modname::{
                         [<$traitname Behavior>],
                         [<$traitname BehaviorStorage>]
                     };
 
-                    pub use crate::[<impl_ $modname>];
+                    pub(crate) use crate::[<impl_ $modname>];
                 }
             )*
         }
@@ -40,5 +40,5 @@ generate_preludes! {
 
 pub mod node;
 pub mod node_prelude {
-    pub use super::node::NodeBehavior;
+    pub(crate) use super::node::NodeBehavior;
 }

--- a/packages/rdom/src/behavior/node.rs
+++ b/packages/rdom/src/behavior/node.rs
@@ -23,7 +23,7 @@ pub(crate) trait NodeBehavior {
     /// Clones node
     fn clone_node(&self) -> AnyNodeArc;
     /// [Node.getType](https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeType)
-    fn get_node_type(&self) -> isize;
+    fn node_type(&self) -> isize;
     /// [.querySelector](https://developer.mozilla.org/en-US/docs/Web/API/Document/querySelector)
     fn query_selector(&self, selector: &Selector) -> Result<Option<ElementNodeArc>, DomError>;
 }
@@ -55,7 +55,7 @@ macro_rules! proxy_node_behavior {
             }
             /// [Node.getType](https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeType)
             pub fn node_type(&self) -> isize {
-                <Self as crate::behavior::NodeBehavior>::get_node_type(self)
+                <Self as crate::behavior::NodeBehavior>::node_type(self)
             }
             /// [.querySelector](https://developer.mozilla.org/en-US/docs/Web/API/Document/querySelector)
             pub fn query_selector(&self, selector: &Selector) -> Result<Option<ElementNodeArc>, DomError> {

--- a/packages/rdom/src/behavior/node.rs
+++ b/packages/rdom/src/behavior/node.rs
@@ -9,9 +9,9 @@ use crate::node::AnyNodeArc;
 use crate::node_list::NodeList;
 use crate::selector::Selector;
 
-// NodeBehavior trait will be here for now
+/// NodeBehavior trait for internal use only.
 /// Trait for main functions connected to node behavior.
-pub trait NodeBehavior {
+pub(crate) trait NodeBehavior {
     /// Returns first child
     fn first_child(&self) -> Option<AnyNodeArc>;
     /// Returns last child
@@ -26,4 +26,41 @@ pub trait NodeBehavior {
     fn get_node_type(&self) -> isize;
     /// [.querySelector](https://developer.mozilla.org/en-US/docs/Web/API/Document/querySelector)
     fn query_selector(&self, selector: &Selector) -> Result<Option<ElementNodeArc>, DomError>;
+}
+
+/// Passes methods through to NodeBehavior, for public use.
+#[macro_export]
+macro_rules! proxy_node_behavior {
+    () => {
+        paste::paste! {
+            /// Returns first child
+            pub fn first_child(&self) -> Option<AnyNodeArc> {
+                <Self as crate::behavior::NodeBehavior>::first_child(self)
+            }
+            /// Returns last child
+            pub fn last_child(&self) -> Option<AnyNodeArc> {
+                <Self as crate::behavior::NodeBehavior>::last_child(self)
+            }
+            /// Adds child to child list
+            pub fn append_child(&self, other: AnyNodeArc) {
+                <Self as crate::behavior::NodeBehavior>::append_child(self, other)
+            }
+            /// Gets live list of all child nodes
+            pub fn child_nodes(&self) -> Arc<NodeList> {
+                <Self as crate::behavior::NodeBehavior>::child_nodes(self)
+            }
+            /// Clones node
+            pub fn clone_node(&self) -> AnyNodeArc {
+                <Self as crate::behavior::NodeBehavior>::clone_node(self)
+            }
+            /// [Node.getType](https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeType)
+            pub fn node_type(&self) -> isize {
+                <Self as crate::behavior::NodeBehavior>::get_node_type(self)
+            }
+            /// [.querySelector](https://developer.mozilla.org/en-US/docs/Web/API/Document/querySelector)
+            pub fn query_selector(&self, selector: &Selector) -> Result<Option<ElementNodeArc>, DomError> {
+                <Self as crate::behavior::NodeBehavior>::query_selector(self, selector)
+            }
+        }
+    };
 }

--- a/packages/rdom/src/behavior/parent_node.rs
+++ b/packages/rdom/src/behavior/parent_node.rs
@@ -6,7 +6,7 @@ use crate::node::contents::NodeType;
 use crate::node::NodeCommon;
 use crate::selector::Selector;
 
-pub trait ParentNodeBehavior {
+pub(crate) trait ParentNodeBehavior {
     fn child_element_count(&self) -> Result<usize, DomError>;
 }
 

--- a/packages/rdom/src/behavior/parent_node.rs
+++ b/packages/rdom/src/behavior/parent_node.rs
@@ -6,6 +6,7 @@ use crate::node::contents::NodeType;
 use crate::node::NodeCommon;
 use crate::selector::Selector;
 
+/// ParentNodeBehavior trait for internal use only.
 pub(crate) trait ParentNodeBehavior {
     fn child_element_count(&self) -> Result<usize, DomError>;
 }
@@ -47,7 +48,7 @@ impl ParentNodeBehaviorStorage {
     }
 }
 
-/// Implements ParentBehavior
+/// Implements ParentNodeBehavior
 #[macro_export]
 macro_rules! impl_parent_node {
     ($structname: ty, $($fieldname: ident).+) => {
@@ -56,6 +57,19 @@ macro_rules! impl_parent_node {
                 fn child_element_count(&self) -> Result<usize, DomError> {
                     self.$($fieldname).+.child_element_count()
                 }
+            }
+        }
+    };
+}
+
+/// Passes methods through to ParentNodeBehavior, for public use.
+#[macro_export]
+macro_rules! proxy_parent_node_behavior {
+    () => {
+        paste::paste! {
+            /// Number of child elements
+            pub fn child_element_count(&self) -> Result<usize, DomError> {
+                <Self as crate::behavior::ParentNodeBehavior>::child_element_count(self)
             }
         }
     };

--- a/packages/rdom/src/behavior/sandbox_member.rs
+++ b/packages/rdom/src/behavior/sandbox_member.rs
@@ -2,6 +2,6 @@ use std::sync::Weak;
 
 use crate::internal_prelude::*;
 
-pub trait SandboxMemberBehavior {
+pub(crate) trait SandboxMemberBehavior {
     fn get_context(&self) -> Weak<Sandbox>;
 }

--- a/packages/rdom/src/node/concrete.rs
+++ b/packages/rdom/src/node/concrete.rs
@@ -2,7 +2,7 @@
 
 use crate::internal_prelude::*;
 use crate::selector::Selector;
-use crate::{proxy_parent_node_behavior, proxy_node_behavior};
+use crate::{proxy_node_behavior, proxy_parent_node_behavior};
 
 use super::contents::{
     AttributeStore, CDataSectionStore, CommentStore, DocumentFragmentStore, DocumentStore,

--- a/packages/rdom/src/node/concrete.rs
+++ b/packages/rdom/src/node/concrete.rs
@@ -157,7 +157,7 @@ macro_rules! impl_concrete {
                         AnyNodeArc::from(self.clone()).clone_node()
                     }
 
-                    fn get_node_type(&self) -> isize {
+                    fn node_type(&self) -> isize {
                         $ti
                     }
 

--- a/packages/rdom/src/node/concrete.rs
+++ b/packages/rdom/src/node/concrete.rs
@@ -2,6 +2,7 @@
 
 use crate::internal_prelude::*;
 use crate::selector::Selector;
+use crate::proxy_node_behavior;
 
 use super::contents::{
     AttributeStore, CDataSectionStore, CommentStore, DocumentFragmentStore, DocumentStore,
@@ -77,6 +78,8 @@ macro_rules! impl_concrete {
 
                         ConcreteNodeArc { contents, common }
                     }
+
+                    proxy_node_behavior!();
                 }
 
                 impl Buildable for ConcreteNodeArc<[<$name Store>]> {

--- a/packages/rdom/src/node/concrete.rs
+++ b/packages/rdom/src/node/concrete.rs
@@ -2,7 +2,7 @@
 
 use crate::internal_prelude::*;
 use crate::selector::Selector;
-use crate::proxy_node_behavior;
+use crate::{proxy_parent_node_behavior, proxy_node_behavior};
 
 use super::contents::{
     AttributeStore, CDataSectionStore, CommentStore, DocumentFragmentStore, DocumentStore,
@@ -184,6 +184,14 @@ impl_concrete! {
 
 impl_parent_node!(ConcreteNodeArc<ElementStore>, common.parent_node_behavior);
 impl_parent_node!(ConcreteNodeArc<DocumentStore>, common.parent_node_behavior);
+
+impl ConcreteNodeArc<ElementStore> {
+    proxy_parent_node_behavior!();
+}
+
+impl ConcreteNodeArc<DocumentStore> {
+    proxy_parent_node_behavior!();
+}
 
 impl DocumentNodeArc {
     /// Creates a new text node with the given text contents

--- a/packages/rdom/src/node/mod.rs
+++ b/packages/rdom/src/node/mod.rs
@@ -1,10 +1,10 @@
 //! Types representing references to DOM nodes.
 
+use crate::behavior::sandbox_member::SandboxMemberBehavior;
 use crate::node_list::NodeList;
+use crate::proxy_node_behavior;
 use crate::selector::Selector;
 use crate::{behavior::parent_node_prelude::ParentNodeBehaviorStorage, internal_prelude::*};
-use crate::behavior::sandbox_member::SandboxMemberBehavior;
-use crate::proxy_node_behavior;
 
 use concrete::ElementNodeArc;
 use contents::{NodeContentsArc, NodeContentsWeak};

--- a/packages/rdom/src/node/mod.rs
+++ b/packages/rdom/src/node/mod.rs
@@ -3,8 +3,9 @@
 use crate::node_list::NodeList;
 use crate::selector::Selector;
 use crate::{behavior::parent_node_prelude::ParentNodeBehaviorStorage, internal_prelude::*};
-
 use crate::behavior::sandbox_member::SandboxMemberBehavior;
+use crate::proxy_node_behavior;
+
 use concrete::ElementNodeArc;
 use contents::{NodeContentsArc, NodeContentsWeak};
 use graph_storage::NodeGraphStorage;
@@ -14,7 +15,7 @@ pub mod contents;
 pub mod element;
 pub(crate) mod graph_storage;
 
-pub use crate::behavior::node::NodeBehavior;
+pub(crate) use crate::behavior::node::NodeBehavior;
 
 /// Marker trait implemented by all node storage classes.
 pub trait AnyNodeStore {}
@@ -108,6 +109,8 @@ impl AnyNodeArc {
 
         AnyNodeArc { contents, common }
     }
+
+    proxy_node_behavior!();
 }
 
 impl NodeBehavior for AnyNodeArc {

--- a/packages/rdom/src/node/mod.rs
+++ b/packages/rdom/src/node/mod.rs
@@ -135,7 +135,7 @@ impl NodeBehavior for AnyNodeArc {
         AnyNodeArc::new(self.get_context(), contents)
     }
 
-    fn get_node_type(&self) -> isize {
+    fn node_type(&self) -> isize {
         self.contents.to_node_type().get_node_number()
     }
 

--- a/packages/rdom/src/tests.rs
+++ b/packages/rdom/src/tests.rs
@@ -3,14 +3,13 @@
 use std::convert::{TryFrom, TryInto};
 use std::sync::Arc;
 
-use crate::behavior::parent_node::ParentNodeBehavior;
 use crate::config::ScreenMetrics;
 use crate::node::concrete::*;
 use crate::node::contents::{AttributeStore, CommentStore, NodeType, TextStore};
 use crate::node::element::{
     ElementStore, HtmlBodyStore, HtmlButtonStore, HtmlElementStore, HtmlHtmlStore,
 };
-use crate::node::{AnyNodeArc, NodeBehavior};
+use crate::node::AnyNodeArc;
 use crate::sandbox::Sandbox;
 use crate::selector::Selector;
 
@@ -42,7 +41,7 @@ macro_rules! test_node_creation {
         doc.append_child(node.into());
         assert_eq!(doc.child_nodes().length(), 1);
         assert_eq!(
-            doc.first_child().unwrap().get_node_type(),
+            doc.first_child().unwrap().node_type(),
             $node_type.get_node_number()
         );
 


### PR DESCRIPTION
Achieves several things:

- allows the user to not worry about importing the various behaviors we have, simplifying the interface
- makes those underlying behaviors private